### PR TITLE
Add some features that TreeCorr uses.

### DIFF
--- a/coord/__init__.py
+++ b/coord/__init__.py
@@ -44,7 +44,8 @@ if not os.path.exists(lib_file): # pragma: no cover
 # Load the C functions with cffi
 _ffi = cffi.FFI()
 for file_name in glob.glob(os.path.join(include_dir,'*_C.h')):
-    _ffi.cdef(open(file_name).read())
+    with open(file_name) as f:
+        _ffi.cdef(f.read())
 _lib = _ffi.dlopen(lib_file)
 
 # Explicitly import things that we want to be in the coord namespace

--- a/coord/angleunit.py
+++ b/coord/angleunit.py
@@ -52,6 +52,8 @@ class AngleUnit(object):
 
             :value:     The measure of the unit in radians.
     """
+    valid_names = ['rad', 'deg', 'hr', 'hour', 'arcmin', 'arcsec']
+
     def __init__(self, value):
         """
         :param value:   The measure of the unit in radians.
@@ -95,6 +97,8 @@ class AngleUnit(object):
             :hour or hr:    AngleUnit(pi / 12.)
             :arcmin:        AngleUnit(pi / 180. / 60.)
             :arcsec:        AngleUnit(pi / 180. / 3600.)
+
+        Note: these valid names are listed in AngleUnit.valid_names.
 
         :param unit:    The string name of the unit to return
 

--- a/coord/celestial.py
+++ b/coord/celestial.py
@@ -226,10 +226,10 @@ class CelestialCoord(object):
             >>> dec = 31*degrees/radians    # in radians
 
             >>> CelestialCoord.radec_to_xyz(ra, dec)
-            (-0.8571673007021123, 1.0497271911386187e-16, 0.5150380749100542)
+            (-0.85716730070211233, 1.0497271911386187e-16, 0.51503807491005416)
 
             >>> CelestialCoord(ra * radians, dec * radians).get_xyz()
-            (-0.8571673007021123, 1.0497271911386187e-16, 0.5150380749100542)
+            (-0.85716730070211233, 1.0497271911386187e-16, 0.51503807491005416)
 
         However, the advantage of this function is that the input values may be numpy
         arrays, in which case, the return values will also be numpy arrays.
@@ -265,7 +265,7 @@ class CelestialCoord(object):
             >>> z = 0.530
 
             >>> CelestialCoord.xyz_to_radec(x, y, z)
-            (0.14556615088111796, 0.5586161910485231)
+            (0.14556615088111796, 0.55861619104852311)
 
             >>> c = CelestialCoord.from_xyz(x, y, z)
             >>> c.ra.rad, c.dec.rad

--- a/coord/celestial.py
+++ b/coord/celestial.py
@@ -220,11 +220,16 @@ class CelestialCoord(object):
             y &= r \\cos(dec) \\sin(ra)  \\\\
             z &= r \\sin(dec)
 
-        For a single ra,dec pair, the following are equivalent:
+        For a single ra,dec pair, the following are essentially equivalent:
 
-            >>> x,y,z = CelestialCoord.radec_to_xyz(ra, dec)
+            >>> ra = 12*hours/radians       # May be any angle measured
+            >>> dec = 31*degrees/radians    # in radians
 
-            >>> x,y,z = CelestialCoord(ra * radians, dec * radians).get_xyz()
+            >>> CelestialCoord.radec_to_xyz(ra, dec)
+            (-0.8571673007021123, 1.0497271911386187e-16, 0.5150380749100542)
+
+            >>> CelestialCoord(ra * radians, dec * radians).get_xyz()
+            (-0.8571673007021123, 1.0497271911386187e-16, 0.5150380749100542)
 
         However, the advantage of this function is that the input values may be numpy
         arrays, in which case, the return values will also be numpy arrays.
@@ -253,12 +258,18 @@ class CelestialCoord(object):
             y &= r \\cos(dec) \\sin(ra)  \\\\
             z &= r \\sin(dec)
 
-        For a single (x,y,z) position, the following are equivalent:
+        For a single (x,y,z) position, the following are essentially equivalent:
 
-            >>> ra, dec = CelestialCoord.xyz_to_radec(x, y, z)
+            >>> x = 0.839       # May be any any 3D location
+            >>> y = 0.123       # Not necessarily on unit sphere
+            >>> z = 0.530
 
-            >>> coord = CelestialCoord.from_xyz(x, y, z)
-            >>> ra, dec = coord.ra.rad, coord.dec.rad
+            >>> CelestialCoord.xyz_to_radec(x, y, z)
+            (0.14556615088111796, 0.5586161910485231)
+
+            >>> c = CelestialCoord.from_xyz(x, y, z)
+            >>> c.ra.rad, c.dec.rad
+            (0.145566150881118, 0.558616191048523)
 
         However, the advantage of this function is that the input values may be numpy
         arrays, in which case, the return values will also be numpy arrays.

--- a/coord/celestial.py
+++ b/coord/celestial.py
@@ -209,6 +209,71 @@ class CelestialCoord(object):
         ret._dec = np.arctan2(ret._sindec, ret._cosdec) * radians
         return ret
 
+    @staticmethod
+    def radec_to_xyz(ra, dec, r=1.):
+        """Convert ra, dec (in radians) to 3D x,y,z coordinates on the unit sphere.
+
+        The connection between (ra,dec) and (x,y,z) are given by the following formulae:
+        .. math::
+
+            x &= r \\cos(dec) \\cos(ra)  \\\\
+            y &= r \\cos(dec) \\sin(ra)  \\\\
+            z &= r \\sin(dec)
+
+        For a single ra,dec pair, the following are equivalent:
+
+            >>> x,y,z = CelestialCoord.radec_to_xyz(ra, dec)
+
+            >>> x,y,z = CelestialCoord(ra * radians, dec * radians).get_xyz()
+
+        However, the advantage of this function is that the input values may be numpy
+        arrays, in which case, the return values will also be numpy arrays.
+
+        :param ra:      The right ascension(s) in radians. May be a numpy array.
+        :param dec:     The declination(s) in radians. May be a numpy array.
+        :param r:       The distance(s) from Earth (default 1.). May be a numpy array.
+
+        :returns: x, y, z as a tuple.
+        """
+        import numpy
+        cosdec = numpy.cos(dec)
+        x = cosdec * numpy.cos(ra) * r
+        y = cosdec * numpy.sin(ra) * r
+        z = numpy.sin(dec) * r
+        return x,y,z
+
+    @staticmethod
+    def xyz_to_radec(x, y, z):
+        """Convert 3D x,y,z coordinates to ra, dec (in radians).
+
+        The connection between (ra,dec) and (x,y,z) are given by the following formulae:
+        .. math::
+
+            x &= r \\cos(dec) \\cos(ra)  \\\\
+            y &= r \\cos(dec) \\sin(ra)  \\\\
+            z &= r \\sin(dec)
+
+        For a single (x,y,z) position, the following are equivalent:
+
+            >>> ra, dec = CelestialCoord.xyz_to_radec(x, y, z)
+
+            >>> coord = CelestialCoord.from_xyz(x, y, z)
+            >>> ra, dec = coord.ra.rad, coord.dec.rad
+
+        However, the advantage of this function is that the input values may be numpy
+        arrays, in which case, the return values will also be numpy arrays.
+
+        :param x:       The x position(s) in 3 dimensions. May be a numpy array.
+        :param y:       The y position(s) in 3 dimensions. May be a numpy array.
+        :param z:       The z position(s) in 3 dimensions. May be a numpy array.
+
+        :returns: ra, dec as a tuple.
+        """
+        import numpy
+        ra = numpy.arctan2(y, x)
+        dec = numpy.arctan2(z, numpy.sqrt(x**2+y**2))
+        return ra,dec
+
     def normal(self):
         """Return the coordinate in the "normal" convention of having 0 <= ra < 24 hours.
 

--- a/coord/celestial.py
+++ b/coord/celestial.py
@@ -269,7 +269,7 @@ class CelestialCoord(object):
             >>> z = 0.530
 
             >>> CelestialCoord.xyz_to_radec(x, y, z)
-            (0.14556615088111796, 0.55861619104852311)
+            (0.14556615088111796, 0.558616191048523)
 
             >>> c = CelestialCoord.from_xyz(x, y, z)
             >>> c.ra.rad, c.dec.rad

--- a/coord/celestial.py
+++ b/coord/celestial.py
@@ -252,7 +252,7 @@ class CelestialCoord(object):
         return x,y,z
 
     @staticmethod
-    def xyz_to_radec(x, y, z):
+    def xyz_to_radec(x, y, z, return_r=False):
         """Convert 3D x,y,z coordinates to ra, dec (in radians).
 
         The connection between (ra,dec) and (x,y,z) are given by the following formulae:
@@ -281,9 +281,11 @@ class CelestialCoord(object):
         :param x:       The x position(s) in 3 dimensions. May be a numpy array.
         :param y:       The y position(s) in 3 dimensions. May be a numpy array.
         :param z:       The z position(s) in 3 dimensions. May be a numpy array.
+        :param return_r: Whether to return r as well as ra, dec. (default: False)
 
-        :returns: ra, dec as a tuple.
+        :returns: ra, dec as a tuple.  Or if return_r is True, (ra, dec, r).
         """
+        xy2 = x**2 + y**2
         ra = np.arctan2(y, x)
         # Note: We don't need arctan2, since always quadrant 1 or 4.
         #       Using plain arctan is slightly faster.  About 10% for the whole function.
@@ -291,8 +293,11 @@ class CelestialCoord(object):
         #       It still gives the right answer, but we catch and ignore the warning here.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",category=RuntimeWarning)
-            dec = np.arctan(z/np.sqrt(x**2+y**2))
-        return ra,dec
+            dec = np.arctan(z/np.sqrt(xy2))
+        if return_r:
+            return ra, dec, np.sqrt(xy2 + z**2)
+        else:
+            return ra, dec
 
     def normal(self):
         """Return the coordinate in the "normal" convention of having 0 <= ra < 24 hours.

--- a/tests/test_angleunit.py
+++ b/tests/test_angleunit.py
@@ -163,6 +163,10 @@ def test_from_name():
     np.testing.assert_raises(ValueError, coord.AngleUnit.from_name, 'gradians')
     np.testing.assert_raises(ValueError, coord.AngleUnit.from_name, 'spam')
 
+    # Make sure all the angles in AngleUnit.valid_names work
+    for name in coord.AngleUnit.valid_names:
+        assert isinstance(coord.AngleUnit.from_name(name), coord.AngleUnit)
+
 if __name__ == '__main__':
     test_init()
     test_builtin_units()

--- a/tests/test_celestial.py
+++ b/tests/test_celestial.py
@@ -269,6 +269,8 @@ def test_xyz_array():
     x_ar = np.cos(dec_ar) * np.cos(ra_ar)
     y_ar = np.cos(dec_ar) * np.sin(ra_ar)
     z_ar = np.sin(dec_ar)
+    x_ar[-2:] = 0.  # Make sure these are precisely 0 to test edge case of exactly n or s pole
+    y_ar[-2:] = 0.
 
     # Check converting singly:
     for (x,y,z,ra,dec) in zip(x_ar, y_ar, z_ar, ra_ar, dec_ar):
@@ -303,12 +305,19 @@ def test_xyz_array():
     np.testing.assert_allclose(y4, y_ar, rtol=1.e-8, atol=1.e-12)
     np.testing.assert_allclose(z4, z_ar, rtol=1.e-8, atol=1.e-12)
 
-    ra3, dec3 = coord.CelestialCoord.xyz_to_radec(x_ar, y_ar, z_ar)
+    ra4, dec4 = coord.CelestialCoord.xyz_to_radec(x_ar, y_ar, z_ar)
     # check sin, cor, rather than angle, so wrap doesn't matter.
-    np.testing.assert_allclose(np.cos(ra3), np.cos(ra_ar), rtol=1.e-8, atol=1.e-12)
-    np.testing.assert_allclose(np.sin(ra3), np.sin(ra_ar), rtol=1.e-8, atol=1.e-12)
-    np.testing.assert_allclose(np.cos(dec3), np.cos(dec_ar), rtol=1.e-8, atol=1.e-12)
-    np.testing.assert_allclose(np.sin(dec3), np.sin(dec_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.cos(ra4), np.cos(ra_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.sin(ra4), np.sin(ra_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.cos(dec4), np.cos(dec_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.sin(dec4), np.sin(dec_ar), rtol=1.e-8, atol=1.e-12)
+
+    # With r values
+    r_ar = np.linspace(1,100, num=len(ra_ar))
+    x5, y5, z5 = coord.CelestialCoord.radec_to_xyz(ra_ar, dec_ar, r_ar)
+    np.testing.assert_allclose(x5, x_ar * r_ar, rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(y5, y_ar * r_ar, rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(z5, z_ar * r_ar, rtol=1.e-8, atol=1.e-12)
 
 
 @timer

--- a/tests/test_celestial.py
+++ b/tests/test_celestial.py
@@ -299,6 +299,12 @@ def test_xyz_array():
         assert np.isclose(ra2, ra)
         assert np.isclose(dec2, dec)
 
+        ra3, dec3, r3 = coord.CelestialCoord.xyz_to_radec(x, y, z, return_r=True)
+        if ra3 < 0.: ra3 += 2.*pi
+        assert np.isclose(ra3, ra)
+        assert np.isclose(dec3, dec)
+        assert np.isclose(r3, (x**2+y**2+z**2)**0.5)
+
     # Now check converting them all at once
     x4, y4, z4 = coord.CelestialCoord.radec_to_xyz(ra_ar, dec_ar)
     np.testing.assert_allclose(x4, x_ar, rtol=1.e-8, atol=1.e-12)
@@ -318,6 +324,13 @@ def test_xyz_array():
     np.testing.assert_allclose(x5, x_ar * r_ar, rtol=1.e-8, atol=1.e-12)
     np.testing.assert_allclose(y5, y_ar * r_ar, rtol=1.e-8, atol=1.e-12)
     np.testing.assert_allclose(z5, z_ar * r_ar, rtol=1.e-8, atol=1.e-12)
+
+    ra5, dec5, r5 = coord.CelestialCoord.xyz_to_radec(x5, y5, z5, return_r=True)
+    np.testing.assert_allclose(np.cos(ra5), np.cos(ra_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.sin(ra5), np.sin(ra_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.cos(dec5), np.cos(dec_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(np.sin(dec5), np.sin(dec_ar), rtol=1.e-8, atol=1.e-12)
+    np.testing.assert_allclose(r5, r_ar, rtol=1.e-8, atol=1.e-12)
 
 
 @timer


### PR DESCRIPTION
I have had a similar set of classes in TreeCorr for various coordinate calculations I do there.  I'd like to transition over to using Coord and remove the TreeCorr versions of these, but there are a few things I need that aren't in the current Coord package:

* `xyz_to_radec` converts from 3D x,y,z coordinates to ra, dec in radians.  Specifically, this needs to be able to handle numpy arrays.  Other than that, it is equivalent to
```
coord = CelestialCoord.from_xyz(x, y, z)
ra, dec = coord.ra.rad, coord.dec.rad
```
* `radec_to_xyz` converts from ra, dec coordinates in radians to x,y,z.  Again, accepting numpy arrays.  It is otherwise equivalent to
```
x,y,z = CelestialCoord(ra * radians, dec * radians).get_xyz()
```
* `AngleUnit.valid_names` lists the names that are valid inputs to `AngleUnit.from_name`.
* Along the way I fixed @erykoff 's bug report #8.

I don't know if anyone will want to code review this.  But I'll plan to merge this Friday unless someone speaks up.