### PR TITLE
test: update test suite for use with jax-galsim

### DIFF
--- a/coord/_version.py
+++ b/coord/_version.py
@@ -18,5 +18,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = '1.3'
+__version__ = '1.4'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/tests/helper_util.py
+++ b/tests/helper_util.py
@@ -32,7 +32,6 @@ except ImportError:
 from collections import Counter
 import functools
 import time
-import coord
 
 # This file has some helper functions that are used by tests from multiple files to help
 # avoid code duplication.
@@ -53,6 +52,16 @@ def do_pickle(obj, func=(lambda x : x), copyable=True, reprable=True):
                         obj = eval(repr(obj)).  This is often a desirable property of objects,
                         but it may not always be possible (or efficient). [default: True]
     """
+    # This import needs to be hidden from the top-level of this helper module so
+    # that JAX-GalSim can test its implementation of the functionality in coord
+    # using this test suite. The jax-galsim test suite, instead of vendoring the
+    # tests from coord and galsim, uses the upstream test suites. It replaces all
+    # imports of galsim and coord with imports of jax_galsim. This helper file
+    # gets reimported after the initial replacement, and the reimport of coord
+    # breaks the replacement. By delaying the import, we avoid this breakage.
+    # - MRB 2024-07-26
+    import coord
+
     # Test pickle round-trip returns an equivalent (but not identical) object
     print('Try pickling ',obj)  # Note: this implicitly checks that str(obj) works.
     obj2 = pickle.loads(pickle.dumps(obj))

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -77,7 +77,9 @@ def test_invalid():
 
     # Invalid value type
     np.testing.assert_raises(TypeError, coord.Angle, theta, coord.degrees)
-    np.testing.assert_raises(ValueError, coord.Angle, 'spam', coord.degrees)
+    # the jax-galsim version of this class raises a TypeError here
+    # instead of a ValueError
+    np.testing.assert_raises((ValueError, TypeError), coord.Angle, 'spam', coord.degrees)
 
     # Wrong order
     np.testing.assert_raises(TypeError, coord.Angle, coord.degrees, 1.3)
@@ -116,6 +118,10 @@ def test_arith():
     theta2 /= -2
     np.testing.assert_almost_equal(theta2.rad, -pi, decimal=12)
 
+
+@timer
+def test_arith_raises():
+    theta1 = 45. * coord.degrees
     # Check invalid arithmetic
     np.testing.assert_raises(TypeError, coord.Angle.__add__, theta1, 23)
     np.testing.assert_raises(TypeError, coord.Angle.__add__, theta1, '23')

--- a/tests/test_angleunit.py
+++ b/tests/test_angleunit.py
@@ -66,7 +66,9 @@ def test_invalid():
     # Wrong type of value argument
     np.testing.assert_raises(TypeError, coord.AngleUnit, coord.degrees)
     # Also wrong type, but strings give a ValueError
-    np.testing.assert_raises(ValueError, coord.AngleUnit, 'spam')
+    # the jax-galsim version of this class raises a TypeError here
+    # instead of a ValueError
+    np.testing.assert_raises((ValueError, TypeError), coord.AngleUnit, 'spam', coord.degrees)
     # Wrong number of arguments
     np.testing.assert_raises(TypeError, coord.AngleUnit, 1, 3)
     np.testing.assert_raises(TypeError, coord.AngleUnit)

--- a/tests/test_celestial.py
+++ b/tests/test_celestial.py
@@ -89,6 +89,9 @@ def test_init():
     do_pickle(c3)
     do_pickle(c4)
 
+
+@timer
+def test_init_raises():
     # Check some invalid values
     np.testing.assert_raises(TypeError, coord.CelestialCoord, 11 * hours)
     np.testing.assert_raises(TypeError, coord.CelestialCoord, 11 * hours, -37)
@@ -202,11 +205,11 @@ def test_xyz():
     tx = tdec.cos() * tra.cos()
     ty = tdec.cos() * tra.sin()
     tz = tdec.sin()
-    
+
     # Check get_xyz by comparing to true values
     c1 = coord.CelestialCoord(ra=tra, dec=tdec)
     np.testing.assert_almost_equal(c1.get_xyz(), (tx, ty, tz), decimal=12)
-    
+
     # Check ra and dec when setting coordinates with from_xyz
     c2 = coord.CelestialCoord.from_xyz(tx, ty, tz)
     np.testing.assert_almost_equal(c2.ra.rad, tra.rad, decimal=12,
@@ -252,6 +255,9 @@ def test_xyz():
         np.testing.assert_almost_equal(c4.dec.rad, c.dec.rad, decimal=12)
         check_aux(c4)
 
+
+@timer
+def test_xyz_raises():
     # constructing from x,y,z = 0,0,0 is undefined.
     np.testing.assert_raises(ValueError, coord.CelestialCoord.from_xyz, 0., 0., 0.)
 
@@ -424,13 +430,6 @@ def test_greatcircle():
         np.testing.assert_almost_equal(point.ra.wrap(theta).rad, t)
         np.testing.assert_almost_equal(point.dec.rad, 0.)
 
-    np.testing.assert_raises(ValueError, eq1.greatCirclePoint, eq1, theta)
-    np.testing.assert_raises(ValueError, eq2.greatCirclePoint, eq2, theta)
-    # eq1 -> eq3 doesn't trigger this due to rounding errors (y is not exactly 0).
-    # But if we explicitly form eq3 from x,y,z with y=0, it works.
-    eq3b = coord.CelestialCoord.from_xyz(-1, 0, 0)
-    np.testing.assert_raises(ValueError, eq1.greatCirclePoint, eq3b, theta)
-
     # Meridian
     north_pole = coord.CelestialCoord(0 * radians, pi/2 * radians)  # north pole
     south_pole = coord.CelestialCoord(0 * radians, -pi/2 * radians) # south pole
@@ -511,6 +510,20 @@ def test_greatcircle():
 
 
 @timer
+def test_greatcircle_raises():
+    theta = 50 * radians
+    eq1 = coord.CelestialCoord(0 * radians, 0 * radians)  # point on the equator
+    eq2 = coord.CelestialCoord(1 * radians, 0 * radians)  # 1 radian along equator
+
+    np.testing.assert_raises(ValueError, eq1.greatCirclePoint, eq1, theta)
+    np.testing.assert_raises(ValueError, eq2.greatCirclePoint, eq2, theta)
+    # eq1 -> eq3 doesn't trigger this due to rounding errors (y is not exactly 0).
+    # But if we explicitly form eq3 from x,y,z with y=0, it works.
+    eq3b = coord.CelestialCoord.from_xyz(-1, 0, 0)
+    np.testing.assert_raises(ValueError, eq1.greatCirclePoint, eq3b, theta)
+
+
+@timer
 def test_gnomonic_projection():
     """Test the gnomonic projection.
     """
@@ -581,7 +594,7 @@ def test_gnomonic_projection():
 
     # center projects to 0,0 with unit area
     u, v = center.project(center, 'gnomonic')
-    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)')
+    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)', atol=1e-16, rtol=0)
     c2 = center.deproject(u,v, 'gnomonic')
     np.testing.assert_allclose(c2.rad, center.rad, err_msg='(0,0) did not deproject to center')
     np.testing.assert_allclose(np.linalg.det(center.jac_deproject(u, v, 'gnomonic')), 1.,
@@ -721,7 +734,7 @@ def test_stereographic_projection():
 
     # center projects to 0,0 with unit area
     u, v = center.project(center, 'stereographic')
-    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)')
+    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)', atol=1e-16, rtol=0)
     c2 = center.deproject(u,v, 'stereographic')
     np.testing.assert_allclose(c2.rad, center.rad, err_msg='(0,0) did not deproject to center')
     np.testing.assert_allclose(np.linalg.det(center.jac_deproject(u, v, 'stereographic')), 1.,
@@ -805,7 +818,7 @@ def test_lambert_projection():
 
     # center projects to 0,0 with unit area
     u, v = center.project(center, 'lambert')
-    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)')
+    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)', atol=1e-16, rtol=0)
     c2 = center.deproject(u,v, 'lambert')
     np.testing.assert_allclose(c2.rad, center.rad, err_msg='(0,0) did not deproject to center')
     np.testing.assert_allclose(np.linalg.det(center.jac_deproject(u, v, 'lambert')), 1.,
@@ -894,7 +907,7 @@ def test_postel_projection():
 
     # center projects to 0,0 with unit area
     u, v = center.project(center, 'postel')
-    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)')
+    np.testing.assert_allclose([u.rad, v.rad], 0., err_msg='center did not project to (0,0)', atol=1e-16, rtol=0)
     c2 = center.deproject(u,v, 'postel')
     np.testing.assert_allclose(c2.rad, center.rad, err_msg='(0,0) did not deproject to center')
     np.testing.assert_allclose(np.linalg.det(center.jac_deproject(u, v, 'postel')), 1.,


### PR DESCRIPTION
This PR updates the coord test suite so that it can be used with jax-galsim. The updates include

- moving an import to avoid breaking the way jax-galsim replaces coord during testing
- accounting for slightly different errors raised by jax-galsim
- accounting for slightly different numerics raised by jax-galsim
- splitting up some of the tests so that it is easier to figure out breakages