### PR TITLE
Update coverage settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,13 +9,14 @@ coverage:
   status:
     project:
       default:
+        enabled: yes
         target: 100%
         threshold: 1%
         branches: null
 
     patch:
       default:
-        target: auto
+        target: 100%
         threshold: 1%
         branches: null
 
@@ -24,6 +25,3 @@ coverage:
   ignore: null
 
 comment: false
-  #layout: "header, diff, changes, sunburst, uncovered, tree"
-  #branches: null
-  #behavior: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - runci
             - releases/*
 
     pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
         branches:
             - main
             - releases/*
-    workflow_dispatch:
 
 jobs:
     build:
@@ -21,17 +20,17 @@ jobs:
             matrix:
                 # First all python versions in basic linux
                 os: [ ubuntu-latest ]
-                py: [ 3.7, 3.8, 3.9, "3.10", 3.11, pypy3.9 ]
+                py: [ 3.7, 3.8, 3.9, "3.10", 3.11, 3.12 ]
 
                 # Add some other particular combinations to test
                 include:
                     # One in MacOS
                     - os: macos-latest
-                      py: 3.9
+                      py: 3.11
 
                     # Check one on Windows
                     - os: windows-latest
-                      py: 3.9
+                      py: 3.11
 
         steps:
             - uses: actions/checkout@v4
@@ -40,12 +39,12 @@ jobs:
                 fetch-depth: 0
 
             - name: Set up Python ${{ matrix.py }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.py }}
 
             - name: Cache pip
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                 path: ~/.cache/pip
                 key: ${{ runner.os }}-${{ matrix.py }}-pip-${{ hashFiles('requirements.txt') }}
@@ -70,7 +69,7 @@ jobs:
                 pip install -U -r requirements.txt
 
                 # Extra packages needed for testing
-                pip install -U nose codecov coverage pytest astropy
+                pip install -U codecov coverage pytest astropy
 
             - name: List all installed packages for reference
               run: pip list
@@ -82,21 +81,18 @@ jobs:
               run: |
                 cd tests
                 coverage run -m pytest -v
+                coverage combine || true
+                coverage report
+                coverage xml
                 cd ..  # N.B. This seems to happen automatically if omitted.
                        # Less confusing to include it explicitly.
 
             - name: Upload coverage to codecov
               if: matrix.os == 'ubuntu-latest'
-              #uses: codecov/codecov-action@v1  # This didn't work for me.
-              run: |
-                cd tests
-                pwd -P
-                ls -la
-                coverage combine || true  # (Not necessary I think, but just in case.)
-                coverage report
-                ls -la
-                #codecov  # This also didn't work.
-                # cf. https://community.codecov.io/t/github-not-getting-codecov-report-after-switching-from-travis-to-github-actions-for-ci/
-                # The solution was to switch to the bash uploader line instead.
-                bash <(curl -s https://codecov.io/bash)
-                cd ..
+              uses: codecov/codecov-action@v4
+              env:
+                CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+              with:
+                files: tests/coverage.xml
+                fail_ci_if_error: false
+                verbose: true

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,35 +1,13 @@
 [run]
 branch = True
 
+include = **/coord/*
+
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # If you put this in a comment, you can manually exclude code from being covered.
     pragma: no cover
-
-    # Don't complain about missing debug-only code:
-    if self\.debug
-    logger.debug
-
-    # Don't complain if tests don't hit defensive checks that probably shouldn't ever be run.
-    raise AssertionError
-    raise NotImplementedError
-    raise IOError
-    raise MemoryError
-
-    # The rest of these are arguable.  For now keep these enabled...
-    #raise ValueError
-    #raise RuntimeError
-    #raise TypeError
-    #raise AttributeError
-    #raise IndexError
-    #raise KeyError
-
-    # Don't complain about not hitting warning code
-    if suppress_warnings is False:
-    import warnings
-    warnings.warn
-    logger.warning
 
     # Don't complain if non-runnable code isn't run:
     if False:
@@ -37,9 +15,5 @@ exclude_lines =
     if __name__ == .__main__.:
 
     # Don't complain about exceptional circumstances not under control of the test suite
-    except KeyboardInterrupt
-    except IOError
-    except OSError
-
-    # Or code for special cases of older versions of things.
-    except ImportError
+    except .*KeyboardInterrupt
+    except .*OSError


### PR DESCRIPTION
Update some things about how coverage is run, which had gotten out of sync with how codecov now works.  Mostly, (1) we need to use a token now, and (2) the way they want you to specify the relevant directory changed.