### PR TITLE
Fix invalid escape

### DIFF
--- a/coord/angle.py
+++ b/coord/angle.py
@@ -489,7 +489,7 @@ class Angle(object):
         """Convert a string of the form dd:mm:ss.decimal into decimal degrees.
         """
         import re
-        tokens = tuple(filter(None, re.split('([\.\d]+)', dms.strip())))
+        tokens = tuple(filter(None, re.split(r'([\.\d]+)', dms.strip())))
         if len(tokens) <= 1:
             raise ValueError("string is not of the expected format")
         sign = 1


### PR DESCRIPTION
This fixes a regex pattern that contains an invalid escape sequence that causes `DeprecationWarning` in python 3.11 and `SyntaxWarning` in 3.12, 3.13, 3.14 and will produce `SyntaxError` in a later python.